### PR TITLE
Correct broken ABNF

### DIFF
--- a/draft-annevk-johannhof-httpbis-cookies.md
+++ b/draft-annevk-johannhof-httpbis-cookies.md
@@ -787,7 +787,7 @@ Note that the various boolean flags defined as a part
 of the algorithm (i.e., found-time, found-day-of-month, found-month,
 found-year) are initially "not set".
 
-1. Using the grammar below, divide the cookie-date into date-tokens.
+1.  Using the grammar below, divide the cookie-date into date-tokens.
 
     ~~~ abnf
     cookie-date     = *delimiter date-token-list *delimiter


### PR DESCRIPTION
Apparently the removal of a space behind "1." impacted the ABNF formatting. This could not be fixed by also indenting the ABNF by three instead of four spaces. This single-space fix appears to be the only way to resolve this.

Fixes #2.